### PR TITLE
added en_us support

### DIFF
--- a/lang/en_us/atto_wiris.php
+++ b/lang/en_us/atto_wiris.php
@@ -1,0 +1,20 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+$string['pluginname'] = 'WIRIS plugin for Atto';
+$string['wiris_editor_title'] = 'Math editor';
+$string['wiris_cas_title'] = 'Calculator';
+$string['wiris_chem_editor_title'] = 'Chemistry editor';

--- a/lang/en_us/strings.js
+++ b/lang/en_us/strings.js
@@ -1,0 +1,8 @@
+var strings = new Array();
+strings['cancel'] = 'Cancel';
+strings['accept'] = 'OK';
+strings['manual'] = 'Manual';
+strings['latex'] = 'LaTeX';
+strings['close'] = 'Close';
+strings['minimise'] = 'Minimise';
+strings['fullscreen'] = 'Full-screen';


### PR DESCRIPTION
Literally just copied en lang

I did this because atto_wiris broke on a site of ours that uses en_us. Just duplicating the en pack fixed it for us.